### PR TITLE
Add hostname to wifi non-ap mode

### DIFF
--- a/esp8266-nanoleaf-webserver.ino
+++ b/esp8266-nanoleaf-webserver.ino
@@ -317,6 +317,7 @@ void setup() {
     Serial.printf("Connecting to %s\n", ssid);
     if (String(WiFi.SSID()) != String(ssid)) {
       WiFi.begin(ssid, password);
+      WiFi.hostname("Nanoleaf");
     }
   }
 


### PR DESCRIPTION
Add hostname to wifi non-ap mode
    WiFi.hostname("Nanoleaf");