### PR TITLE
Mqtt / Home Assistant / Google Home

### DIFF
--- a/Software_Installation.md
+++ b/Software_Installation.md
@@ -71,8 +71,12 @@ For beginners I would recommend watching this setup tutorial below.
    // Wi-Fi network to connect to (if not in AP mode)
     char* ssid = "your-ssid";
     char* password = "your-password";
+
+   // MQTT user / password
+     const char* mqttUser = "your-mqtt-user";
+     const char* mqttPassword = "your-mqtt-password";
    ```
-   
+
    ![](software_screenshots/secret.png?raw=true)
 
 5. Configure the parameters
@@ -107,7 +111,12 @@ For beginners I would recommend watching this setup tutorial below.
 ![](software_screenshots/alexa_config.png?raw=true)
 
 
+7. (Optional) Configure MQTT
 
+-  Installation of "PubSubClient" and "ArduinoJson" libraries required
+-  Requires `ENABLE_MQTT_SUPPORT`
+-  It's preconfigured for Home Assistant Mosquitto MQTT service
+-  Enables sync with home assistant and from there to Google Assistant
 
 
 ## 3. Upload


### PR DESCRIPTION
fixes NimmLor/esp8266-nanoleaf-webserver#30

Adding the MQTT Protocol to the arduino sketch allows for connection to multiple platforms, local or cloud ones.

The MQTT protocol and channels are preconfigured for automatic discovery and configuration for Home Assistant, and exposing to Google Assistant

Available endpoints are are :
Power
Brightness
RGB
Patterns.

This does not replace Alexa integration, it expands on it, both may be active at the same time.


after exposing the device to Google Assistant from Home Assistant, Google can control by voice : 
Power
Brightness
RGB (Switches to Solid Color Pattern)

to control Patterns by voice add a script to Home Assistant triggering the device in this format

'1586569671485':
  alias: Rainbow Effect
  sequence:
  - data:
      effect: Horizontal Rainbow
    entity_id: light.nanoleafs
    service: light.turn_on

The phrase will then be "Activate <alias>" to trigger the patterns using Voice commands from google home.