### PR TITLE
wifi and mqtt reliability

### DIFF
--- a/esp8266-fastled-iot-webserver.ino
+++ b/esp8266-fastled-iot-webserver.ino
@@ -1116,13 +1116,6 @@ void loop() {
 
 	//  handleIrInput();
 
-	if (power == 0) {
-		fill_solid(leds, NUM_LEDS, CRGB::Black);
-		FastLED.show();
-		// FastLED.delay(15);
-		return;
-	}
-
 	static bool hasConnected = false;
 	EVERY_N_SECONDS(1) {
 		if (WiFi.status() != WL_CONNECTED) {
@@ -1154,13 +1147,11 @@ void loop() {
 			mqttClient.setCallback(mqttCallback);
 			mqttConnected = false;
 		}
-		else {
-			sendStatus();
-		}
 		if (!mqttConnected) {
 			mqttConnected = true;
 			Serial.println("Connecting to MQTT...");
 			if (mqttClient.connect(HOSTNAME, mqttUser, mqttPassword)) {
+				mqttClient.setKeepAlive(10);
 				Serial.println("connected \n");
 
 				Serial.println("Subscribing to MQTT Topics \n");
@@ -1205,7 +1196,18 @@ void loop() {
 			}
 		}
 	}
+
+	EVERY_N_SECONDS(90) {
+		sendStatus();
+	}
 #endif
+
+	if (power == 0) {
+		fill_solid(leds, NUM_LEDS, CRGB::Black);
+		FastLED.show();
+		// FastLED.delay(15);
+		return;
+	}
 
 	// EVERY_N_SECONDS(10) {
 	//   Serial.print( F("Heap: ") ); Serial.println(system_get_free_heap_size());

--- a/esp8266-fastled-iot-webserver.ino
+++ b/esp8266-fastled-iot-webserver.ino
@@ -1184,6 +1184,8 @@ void loop() {
 					}
 					if (mqttClient.endPublish() == true) {
 						Serial.println("Configuration Publishing Finished");
+						sendStatus();
+						Serial.println("Sending Initial Status");
 					}
 				}
 				else {


### PR DESCRIPTION
the return on the if (power == 0) block was preventing the mDNS and MQTT checks from running when power was meant to be off on boot as mDNS and MQTT don't run until the second pass when 

also, when powered off for over an hour, the clients would disconnect as nothing would be flowing between the channels (EVERY_N_SECONDS functions need to be run periodically to work)

This makes both wifi / mqtt reliable over as many hours as you want to keep the lights off without removing wall power from them.