### PR TITLE
Change udp parsing to use 'read' instead of 'readBytes'

### DIFF
--- a/esp8266-fastled-iot-webserver.ino
+++ b/esp8266-fastled-iot-webserver.ino
@@ -3125,7 +3125,7 @@ bool parseUdp()
         nopackage = 0;
         // receive incoming UDP packets
         SERIAL_DEBUG_LNF("Received %d bytes from %s, port %d", packetSize, Udp.remoteIP().toString().c_str(), Udp.remotePort())
-        int len = Udp.readBytes(incomingPacket, PACKET_LENGTH);
+        int len = Udp.read(incomingPacket, PACKET_LENGTH);
         if (len > 0)
         {
             incomingPacket[len] = '\0';


### PR DESCRIPTION
Verified the parsing of udp packets when using visualizer patterns was
taking ~ 1000ms, resulting in a very low fps when using these particular
patterns. Narrowed the timing down to Udp.readBytes(). After being
unable to find a solid reference for readBytes or why it might be taking
so long to return, I tested with a simple 'read()' call and am now
getting normal speeds from the visualizer patterns.

issue #204